### PR TITLE
Properly display fields on other users profiles.

### DIFF
--- a/src/components/UserProfile/elements/EmptyContent.jsx
+++ b/src/components/UserProfile/elements/EmptyContent.jsx
@@ -45,7 +45,7 @@ export default EmptyContent;
 
 EmptyContent.propTypes = {
   onClick: PropTypes.func,
-  children: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
+  children: PropTypes.node,
   showPlusIcon: PropTypes.bool,
 };
 

--- a/src/components/UserProfile/elements/TransitionReplace.jsx
+++ b/src/components/UserProfile/elements/TransitionReplace.jsx
@@ -158,7 +158,7 @@ export default TransitionReplace;
 
 
 TransitionReplace.propTypes = {
-  children: PropTypes.element.isRequired,
+  children: PropTypes.node,
   enterDuration: PropTypes.number,
   exitDuration: PropTypes.number,
   enterFadeEaseFunction: PropTypes.string,
@@ -172,6 +172,7 @@ TransitionReplace.propTypes = {
 };
 
 TransitionReplace.defaultProps = {
+  children: null,
   enterDuration: 300,
   exitDuration: 300,
   enterFadeEaseFunction: 'linear',

--- a/src/components/UserProfile/index.jsx
+++ b/src/components/UserProfile/index.jsx
@@ -88,6 +88,7 @@ class UserProfile extends React.Component {
       education,
       socialLinks,
       certificates,
+      isCurrentUserProfile,
     } = this.props;
 
     const commonProps = {
@@ -101,8 +102,26 @@ class UserProfile extends React.Component {
     };
 
     const getMode = (name) => {
-      if (name === this.props.currentlyEditingField) return 'editing';
-      if (!this.props[name] || !this.props[name].length) return 'empty';
+      // If the prop doesn't exist, that means it hasn't been set (for the current user's profile)
+      // or is being hidden from us (for other users' profiles)
+      const propExists = this.props[name] != null && this.props[name].length > 0;
+
+      // If this isn't the current user's profile...
+      if (!isCurrentUserProfile) {
+        // then there are only two options: static or nothing.
+        // We use 'null' as a return value because the consumers of
+        // getMode render nothing at all on a mode of null.
+        return propExists ? 'static' : null;
+      }
+      // Otherwise, if this is the current user's profile...
+      if (name === this.props.currentlyEditingField) {
+        return 'editing';
+      }
+
+      if (!propExists) {
+        return 'empty';
+      }
+
       return 'editable';
     };
 
@@ -184,6 +203,7 @@ UserProfile.propTypes = {
   saveState: PropTypes.oneOf([null, 'pending', 'complete', 'error']),
   savePhotoState: PropTypes.oneOf([null, 'pending', 'complete', 'error']),
   error: PropTypes.string,
+  isCurrentUserProfile: PropTypes.bool.isRequired,
   profileImage: PropTypes.string,
   fullName: PropTypes.string,
   username: PropTypes.string,

--- a/src/containers/UserProfile/index.jsx
+++ b/src/containers/UserProfile/index.jsx
@@ -16,6 +16,7 @@ const mapStateToProps = (state) => {
       ? state.profilePage.profile.profileImage.imageUrlLarge
       : null;
   return {
+    isCurrentUserProfile: state.userAccount.username === state.profilePage.profile.username,
     currentlyEditingField: state.profilePage.currentlyEditingField,
     saveState: state.profilePage.saveState,
     savePhotoState: state.profilePage.savePhotoState,


### PR DESCRIPTION
If a field isn’t present in another users profile (they either haven’t set it, or it’s not publicly visible), then hide it completely.  If the field is present, then show it in a static way.

The change to EmptyContent was because I kept getting a warning from it, and I think `node` is more accurate to what we expect there.  Similarly, I modified TransitionReplace so that it could render "nothing at all" if desired.  This is used for hidden fields as described above.
