### PR TITLE
TransitionReplace Improvement

### DIFF
--- a/src/components/UserProfile/elements/TransitionReplace.jsx
+++ b/src/components/UserProfile/elements/TransitionReplace.jsx
@@ -36,20 +36,21 @@ class TransitionReplace extends React.Component {
   }
 
   onChildEntering(htmlNode) {
-    // subtract 1 from the height to improve shifts at the end of the animation
     this.setState({
-      height: htmlNode.offsetHeight - 1,
+      height: htmlNode.offsetHeight,
     });
   }
 
   onChildEntered(htmlNode) {
     if (this.props.onChildEntered) this.props.onChildEntered(htmlNode);
+    this.setState({
+      height: null,
+    });
   }
 
   onChildExit(htmlNode) {
-    // subtract 1 from the height to improve shifts at the end of the animation
     this.setState({
-      height: htmlNode.offsetHeight - 1,
+      height: htmlNode.offsetHeight,
     });
 
     if (this.props.onChildExit) this.props.onChildExit(htmlNode);


### PR DESCRIPTION
Since we've added the ability for transition replace to have no content, we can't guarantee an onChildExited event will fire resetting the hieght to null