### PR TITLE
Add age messaging

### DIFF
--- a/src/components/ProfilePage.jsx
+++ b/src/components/ProfilePage.jsx
@@ -21,6 +21,7 @@ import Education from './ProfilePage/Education';
 import SocialLinks from './ProfilePage/SocialLinks';
 import Bio from './ProfilePage/Bio';
 import MyCertificates from './ProfilePage/MyCertificates';
+import AgeMessage from './ProfilePage/AgeMessage';
 
 export class ProfilePage extends React.Component {
   constructor(props) {
@@ -210,6 +211,8 @@ export class ProfilePage extends React.Component {
             </Col>
             <Col xs={{ order: 1 }} md={{ size: 8, order: 2 }} lg={{ size: 8, offset: 1 }} className="mt-4 mt-md-n5">
 
+              {this.props.requiresParentalConsent ? <AgeMessage accountURL="#account" /> : null}
+
               <Bio
                 bio={bio}
                 visibility={getVisibility('bio')}
@@ -266,6 +269,8 @@ ProfilePage.propTypes = {
   }).isRequired,
   accountPrivacy: PropTypes.string,
   visibility: PropTypes.object, // eslint-disable-line
+  yearOfBirth: PropTypes.number,
+  requiresParentalConsent: PropTypes.bool,
 };
 
 ProfilePage.defaultProps = {
@@ -284,6 +289,8 @@ ProfilePage.defaultProps = {
   certificates: null,
   accountPrivacy: null,
   visibility: {}, // eslint-disable-line
+  yearOfBirth: null,
+  requiresParentalConsent: null,
 };
 
 const mapStateToProps = (state) => {
@@ -307,6 +314,8 @@ const mapStateToProps = (state) => {
     certificates: state.profilePage.profile.certificates,
     accountPrivacy: state.profilePage.preferences.accountPrivacy,
     visibility: state.profilePage.preferences.visibility || {},
+    yearOfBirth: state.profilePage.profile.yearOfBirth,
+    requiresParentalConsent: state.profilePage.profile.requiresParentalConsent,
   };
 };
 

--- a/src/components/ProfilePage/AgeMessage.jsx
+++ b/src/components/ProfilePage/AgeMessage.jsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { UncontrolledAlert } from 'reactstrap';
+
+function AgeMessage({ accountURL }) {
+  return (
+    <UncontrolledAlert color="info">
+      <h6>Your profile cannot be shared.</h6>
+      <p>
+        To share your profile with other edX learners,
+        you must confirm that you are over the age of 13.
+      </p>
+      <a href={accountURL}>Set your date of birth</a>
+    </UncontrolledAlert>
+  );
+}
+
+AgeMessage.propTypes = {
+  accountURL: PropTypes.string.isRequired,
+};
+
+export default AgeMessage;

--- a/src/index.scss
+++ b/src/index.scss
@@ -58,18 +58,17 @@ $fa-font-path: "~font-awesome/fonts";
   }
 
   .profile-avatar {
-    max-width: 50%;
     width: 5rem;
     height: 5rem;
     position: relative;
 
     @include media-breakpoint-up(md) {
       width: 12rem;
-      max-width: none;
       height: 12rem;
     }
 
     .profile-avatar-edit-button {
+      border: none;
       position: absolute;
       height: 100%;
       left: 0;

--- a/src/sagas/RootSaga.js
+++ b/src/sagas/RootSaga.js
@@ -124,7 +124,7 @@ export function* handleSaveProfilePhoto(action) {
     yield call(ProfileApiService.postProfilePhoto, username, formData);
 
     // Get the account data. Saving doesn't return anything on success.
-    yield handleFetchProfile(fetchProfileAction);
+    yield handleFetchProfile(fetchProfileAction(username));
 
     yield put(saveProfilePhotoSuccess());
     yield put(saveProfilePhotoReset());
@@ -141,7 +141,7 @@ export function* handleDeleteProfilePhoto(action) {
     yield call(ProfileApiService.deleteProfilePhoto, username);
 
     // Get the account data. Saving doesn't return anything on success.
-    yield handleFetchProfile(fetchProfileAction);
+    yield handleFetchProfile(fetchProfileAction(username));
 
     yield put(deleteProfilePhotoSuccess());
     yield put(deleteProfilePhotoReset());


### PR DESCRIPTION
Looks only at the `requiresParentalConsent` boolean. It seems that this is false when `yearOfBirth` is null or less than 13 years ago. It's worth noting that this differs from the [current logic on the profile page](https://github.com/edx/edx-platform/blob/1a8df4517943a15b2d1c71be8ea44c4f6382d00c/lms/static/js/student_account/models/user_account_model.js#L58) seen here:
```
isAboveMinimumAge: function() {
    var yearOfBirth = this.get('year_of_birth');
    var isBirthDefined = !(_.isUndefined(yearOfBirth) || _.isNull(yearOfBirth));
    return isBirthDefined && !(this.get('requires_parental_consent'));
}
```
