### PR TITLE
Fix age messaging

### DIFF
--- a/src/services/ProfileApiService.js
+++ b/src/services/ProfileApiService.js
@@ -9,6 +9,8 @@ const clientToServerKeyMap = {
   dateJoined: 'date_joined',
   languageProficiencies: 'language_proficiencies',
   accountPrivacy: 'account_privacy',
+  yearOfBirth: 'year_of_birth',
+  requiresParentalConsent: 'requires_parental_consent',
 };
 const serverToClientKeyMap = Object.entries(clientToServerKeyMap).reduce((acc, [key, value]) => {
   acc[value] = key;


### PR DESCRIPTION
`yearOfBirth` and `requiresParentalConsent` were missing from redux state. This adds them to the clientServer key map in ProfileAPIService.