### PR TITLE
Add language proficiency field

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2436,8 +2436,13 @@
         }
       }
     },
+    "@cospired/i18n-iso-languages": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@cospired/i18n-iso-languages/-/i18n-iso-languages-2.0.2.tgz",
+      "integrity": "sha512-APBpZvdQrC1MJWMzk33V7FR2RhBRtnH2QPLqZzS+qia7PixwgWNlnX7UfHjhx+YWkM53GdsZKs40EBkSwADuMA=="
+    },
     "@edx/edx-bootstrap": {
-      "version": "git://github.com/edx/edx-bootstrap.git#71fd3272d235eb133cccefc1ce63f35a7696bf28",
+      "version": "git://github.com/edx/edx-bootstrap.git#e14bb7b678037a675e26c1b196f800e0f573f22e",
       "from": "git://github.com/edx/edx-bootstrap.git#update-with-documentation-site",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "^1.2.13",
@@ -11911,6 +11916,11 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
+    },
+    "iso-countries-languages": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/iso-countries-languages/-/iso-countries-languages-0.2.1.tgz",
+      "integrity": "sha512-MSLwTToJmw0VS/NdCvwsgt28zE5A/rGsPpdPOrepFgAanVDBUguAgGj/73NTIrLifICz2pTmJNHZNPwDXmAMTw=="
     },
     "isobject": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@cospired/i18n-iso-languages": "^2.0.2",
     "@edx/edx-bootstrap": "git://github.com/edx/edx-bootstrap.git#update-with-documentation-site",
     "@edx/frontend-auth": "^2.0.0",
     "@edx/frontend-component-footer": "^2.0.0",
@@ -45,6 +46,7 @@
     "font-awesome": "^4.7.0",
     "history": "^4.7.2",
     "i18n-iso-countries": "^3.7.8",
+    "iso-countries-languages": "^0.2.1",
     "lodash.defaultsdeep": "^4.6.0",
     "lodash.set": "^4.3.2",
     "prop-types": "^15.5.10",

--- a/src/components/ProfilePage.jsx
+++ b/src/components/ProfilePage.jsx
@@ -19,6 +19,7 @@ import {
 import ProfileAvatar from './ProfilePage/ProfileAvatar';
 import Name from './ProfilePage/Name';
 import Country from './ProfilePage/Country';
+import PreferredLanguage from './ProfilePage/PreferredLanguage';
 import Education from './ProfilePage/Education';
 import SocialLinks from './ProfilePage/SocialLinks';
 import Bio from './ProfilePage/Bio';
@@ -108,6 +109,7 @@ export class ProfilePage extends React.Component {
             <Col xs={{ order: 2 }} md={{ size: 4, order: 1 }} lg={3} className="mt-md-4">
               <Name formId="name" {...commonFormProps} />
               <Country formId="country" {...commonFormProps} />
+              <PreferredLanguage formId="languageProficiencies" {...commonFormProps} />
               <Education formId="education" {...commonFormProps} />
               <SocialLinks formId="socialLinks" {...commonFormProps} />
             </Col>

--- a/src/components/ProfilePage/PreferredLanguage.jsx
+++ b/src/components/ProfilePage/PreferredLanguage.jsx
@@ -31,10 +31,13 @@ class PreferredLanguage extends React.Component {
       name,
       value: rawValue,
     } = e.target;
+    let value = rawValue;
     // Restructure the data.
     // We deconstruct our value prop in render() so this
     // changes our data's shape back to match what came in
-    const value = [{ code: rawValue }];
+    if (name === this.props.formId) {
+      value = [{ code: rawValue }];
+    }
 
     this.props.changeHandler(this.props.formId, name, value);
   }
@@ -67,7 +70,13 @@ class PreferredLanguage extends React.Component {
           editing: (
             <Form onSubmit={this.handleSubmit}>
               <FormGroup>
-                <Label for="language">Preferred Language</Label>
+                <Label for="language">
+                  <FormattedMessage
+                    id="profile.preferredlanguage.label"
+                    defaultMessage="Language"
+                    description="Preferred language label"
+                  />
+                </Label>
                 <Input
                   type="select"
                   name={formId}
@@ -94,7 +103,13 @@ class PreferredLanguage extends React.Component {
           editable: (
             <React.Fragment>
               <EditableItemHeader
-                content="Preferred Language"
+                content={(
+                  <FormattedMessage
+                    id="profile.preferredlanguage.label"
+                    defaultMessage="Language"
+                    description="Preferred language label"
+                  />
+                )}
                 showEditButton
                 onClickEdit={this.handleOpen}
                 showVisibility={visibility !== null}
@@ -114,7 +129,15 @@ class PreferredLanguage extends React.Component {
           ),
           static: (
             <React.Fragment>
-              <EditableItemHeader content="Location" />
+              <EditableItemHeader
+                content={(
+                  <FormattedMessage
+                    id="profile.preferredlanguage.label"
+                    defaultMessage="Language"
+                    description="Preferred language label"
+                  />
+                )}
+              />
               <h5>{ALL_LANGUAGES[value]}</h5>
             </React.Fragment>
           ),
@@ -132,7 +155,12 @@ PreferredLanguage.propTypes = {
   formId: PropTypes.string.isRequired,
 
   // From Selector
-  value: PropTypes.arrayOf(PropTypes.shape({ code: PropTypes.string })),
+  value: PropTypes.oneOfType([
+    PropTypes.arrayOf(PropTypes.shape({ code: PropTypes.string })),
+    // TODO: ProfilePageSelector should supply null values
+    // instead of empty strings when no value exists
+    PropTypes.oneOf(['']),
+  ]),
   visibility: PropTypes.oneOf(['private', 'all_users']),
   editMode: PropTypes.oneOf(['editing', 'editable', 'empty', 'static']),
   saveState: PropTypes.string,

--- a/src/components/ProfilePage/PreferredLanguage.jsx
+++ b/src/components/ProfilePage/PreferredLanguage.jsx
@@ -1,0 +1,159 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Form, FormFeedback, FormGroup, Input, Label } from 'reactstrap';
+import { connect } from 'react-redux';
+import { FormattedMessage } from 'react-intl';
+
+// Components
+import FormControls from './elements/FormControls';
+import EditableItemHeader from './elements/EditableItemHeader';
+import EmptyContent from './elements/EmptyContent';
+import SwitchContent from './elements/SwitchContent';
+
+// Constants
+import { ALL_LANGUAGES } from '../../constants/languages';
+
+// Selectors
+import { editableFormSelector } from '../../selectors/ProfilePageSelector';
+
+class PreferredLanguage extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.handleChange = this.handleChange.bind(this);
+    this.handleSubmit = this.handleSubmit.bind(this);
+    this.handleClose = this.handleClose.bind(this);
+    this.handleOpen = this.handleOpen.bind(this);
+  }
+
+  handleChange(e) {
+    const {
+      name,
+      value: rawValue,
+    } = e.target;
+    // Restructure the data.
+    // We deconstruct our value prop in render() so this
+    // changes our data's shape back to match what came in
+    const value = [{ code: rawValue }];
+
+    this.props.changeHandler(this.props.formId, name, value);
+  }
+
+  handleSubmit(e) {
+    e.preventDefault();
+    this.props.submitHandler(this.props.formId);
+  }
+
+  handleClose() {
+    this.props.closeHandler(this.props.formId);
+  }
+
+  handleOpen() {
+    this.props.openHandler(this.props.formId);
+  }
+
+  render() {
+    const {
+      formId, value: valueArr, visibility, editMode, saveState, error,
+    } = this.props;
+
+    const value = valueArr.length ? valueArr[0].code : '';
+
+    return (
+      <SwitchContent
+        className="mb-4"
+        expression={editMode}
+        cases={{
+          editing: (
+            <Form onSubmit={this.handleSubmit}>
+              <FormGroup>
+                <Label for="language">Preferred Language</Label>
+                <Input
+                  type="select"
+                  name={formId}
+                  className="w-100"
+                  value={value}
+                  invalid={error != null}
+                  onChange={this.handleChange}
+                >
+                  {Object.entries(ALL_LANGUAGES).map(([code, name]) => (
+                    <option key={code} value={code}>{name}</option>
+                  ))}
+                </Input>
+                <FormFeedback>{error}</FormFeedback>
+              </FormGroup>
+              <FormControls
+                formId={formId}
+                saveState={saveState}
+                visibility={visibility}
+                cancelHandler={this.handleClose}
+                changeHandler={this.handleChange}
+              />
+            </Form>
+          ),
+          editable: (
+            <React.Fragment>
+              <EditableItemHeader
+                content="Preferred Language"
+                showEditButton
+                onClickEdit={this.handleOpen}
+                showVisibility={visibility !== null}
+                visibility={visibility}
+              />
+              <h5>{ALL_LANGUAGES[value]}</h5>
+            </React.Fragment>
+          ),
+          empty: (
+            <EmptyContent onClick={this.handleOpen}>
+              <FormattedMessage
+                id="profile.preferredlanguage.empty"
+                defaultMessage="Add language"
+                description="instructions when the user doesn't have a location set"
+              />
+            </EmptyContent>
+          ),
+          static: (
+            <React.Fragment>
+              <EditableItemHeader content="Location" />
+              <h5>{ALL_LANGUAGES[value]}</h5>
+            </React.Fragment>
+          ),
+        }}
+      />
+    );
+  }
+}
+
+PreferredLanguage.propTypes = {
+  // It'd be nice to just set this as a defaultProps...
+  // except the class that comes out on the other side of react-redux's
+  // connect() method won't have it anymore. Static properties won't survive
+  // through the higher order function.
+  formId: PropTypes.string.isRequired,
+
+  // From Selector
+  value: PropTypes.arrayOf(PropTypes.shape({ code: PropTypes.string })),
+  visibility: PropTypes.oneOf(['private', 'all_users']),
+  editMode: PropTypes.oneOf(['editing', 'editable', 'empty', 'static']),
+  saveState: PropTypes.string,
+  error: PropTypes.string,
+
+  // Actions
+  changeHandler: PropTypes.func.isRequired,
+  submitHandler: PropTypes.func.isRequired,
+  closeHandler: PropTypes.func.isRequired,
+  openHandler: PropTypes.func.isRequired,
+};
+
+PreferredLanguage.defaultProps = {
+  editMode: 'static',
+  saveState: null,
+  value: null,
+  visibility: 'private',
+  error: null,
+};
+
+export default connect(
+  editableFormSelector,
+  {},
+)(PreferredLanguage);

--- a/src/components/ProfilePage/elements/EditableItemHeader.jsx
+++ b/src/components/ProfilePage/elements/EditableItemHeader.jsx
@@ -31,7 +31,7 @@ EditableItemHeader.propTypes = {
   onClickEdit: PropTypes.func,
   showVisibility: PropTypes.bool,
   showEditButton: PropTypes.bool,
-  content: PropTypes.string,
+  content: PropTypes.node,
   visibility: PropTypes.oneOf(['private', 'all_users']),
 };
 

--- a/src/constants/languages.js
+++ b/src/constants/languages.js
@@ -1,0 +1,7 @@
+import LANGUAGES from '@cospired/i18n-iso-languages';
+
+LANGUAGES.registerLocale(require('@cospired/i18n-iso-languages/langs/en.json'));
+
+const ALL_LANGUAGES = LANGUAGES.getNames('en');
+
+export { ALL_LANGUAGES, LANGUAGES };


### PR DESCRIPTION
It only displays and saves one – parity with the profile page today.
The API is prepared to handle an array of languages when we're ready