### PR TITLE
ARCH-491: Rename event to edx.profile.viewed.

### DIFF
--- a/src/components/ProfilePage.jsx
+++ b/src/components/ProfilePage.jsx
@@ -42,8 +42,7 @@ export class ProfilePage extends React.Component {
 
   componentDidMount() {
     this.props.fetchProfile(this.props.match.params.username);
-    // TODO: Rename 'edx.bi.profile.viewed' when the event is finalized
-    logEvent('edx.bi.profile.viewed', {
+    logEvent('edx.profile.viewed', {
       username: this.props.match.params.username,
     });
   }

--- a/src/components/ProfilePage.test.jsx
+++ b/src/components/ProfilePage.test.jsx
@@ -39,7 +39,7 @@ describe('<ProfilePage />', () => {
       ));
 
       expect(analytics.logEvent.mock.calls.length).toBe(1);
-      expect(analytics.logEvent.mock.calls[0][0]).toEqual('edx.bi.profile.viewed');
+      expect(analytics.logEvent.mock.calls[0][0]).toEqual('edx.profile.viewed');
       expect(analytics.logEvent.mock.calls[0][1]).toEqual({
         username: 'test-username',
       });


### PR DESCRIPTION
Had temporarily named the event edx.bi.profile.viewed while working
out some details. Now that the backend will add user_id for the
username, the event can become more official.

ARCH-491

- [X] **Important:** Do not merge until https://github.com/edx/edx-platform/pull/19949 lands in Prod.