### PR TITLE
fix(certificates): handle absolute and relative certificate download urls

### DIFF
--- a/src/services/ProfileApiService.js
+++ b/src/services/ProfileApiService.js
@@ -116,7 +116,7 @@ function transformCertificateData(data) {
     transformedData.push({
       ...camelCaseObject(cert),
       certificateType: CERTIFICATE_TYPES[cert.certificate_type],
-      downloadUrl: `${configuration.LMS_BASE_URL}${cert.download_url}`,
+      downloadUrl: new URL(cert.download_url, configuration.LMS_BASE_URL).toString(),
     });
   });
   return transformedData;


### PR DESCRIPTION
The certificates API can return both absolute and relative download URLs depending on whether or not the certificate is PDF or web.