### PR TITLE
fix: remove the upload button background when viewing other profiles

### DIFF
--- a/src/components/ProfilePage/ProfileAvatar.jsx
+++ b/src/components/ProfilePage/ProfileAvatar.jsx
@@ -60,52 +60,60 @@ class ProfileAvatar extends React.Component {
   renderMenu() {
     if (!this.props.isEditable) return null;
 
-    if (this.props.isDefault) {
-      return (
-        <Button
-          className="text-white btn-block"
-          color="link"
-          size="sm"
-          onClick={this.onClickUpload}
-        >
-          <FormattedMessage
-            id="profile.profileavatar.upload-button"
-            defaultMessage="Upload Photo"
-            description="Upload photo button"
-          />
-        </Button>
-      );
-    }
-
-    return (
-      <Dropdown
-        isOpen={this.state.dropdownOpen}
-        toggle={this.toggleDropdown}
-      >
-        <DropdownToggle className="text-white btn-block" color="link" size="sm">
-          <FormattedMessage
-            id="profile.profileavatar.change-button"
-            defaultMessage="Change"
-            description="Change photo button"
-          />
-        </DropdownToggle>
-        <DropdownMenu>
-          <DropdownItem onClick={this.onClickUpload}>
+    const menuContent = ((isDefault) => {
+      if (isDefault) {
+        return (
+          <Button
+            className="text-white btn-block"
+            color="link"
+            size="sm"
+            onClick={this.onClickUpload}
+          >
             <FormattedMessage
               id="profile.profileavatar.upload-button"
               defaultMessage="Upload Photo"
               description="Upload photo button"
             />
-          </DropdownItem>
-          <DropdownItem onClick={this.onClickDelete}>
+          </Button>
+        );
+      }
+
+      return (
+        <Dropdown
+          isOpen={this.state.dropdownOpen}
+          toggle={this.toggleDropdown}
+        >
+          <DropdownToggle className="text-white btn-block" color="link" size="sm">
             <FormattedMessage
-              id="profile.profileavatar.remove.button"
-              defaultMessage="Remove"
-              description="Remove photo button"
+              id="profile.profileavatar.change-button"
+              defaultMessage="Change"
+              description="Change photo button"
             />
-          </DropdownItem>
-        </DropdownMenu>
-      </Dropdown>
+          </DropdownToggle>
+          <DropdownMenu>
+            <DropdownItem onClick={this.onClickUpload}>
+              <FormattedMessage
+                id="profile.profileavatar.upload-button"
+                defaultMessage="Upload Photo"
+                description="Upload photo button"
+              />
+            </DropdownItem>
+            <DropdownItem onClick={this.onClickDelete}>
+              <FormattedMessage
+                id="profile.profileavatar.remove.button"
+                defaultMessage="Remove"
+                description="Remove photo button"
+              />
+            </DropdownItem>
+          </DropdownMenu>
+        </Dropdown>
+      );
+    })(this.props.isDefault);
+
+    return (
+      <div className="profile-avatar-menu-container">
+        {menuContent}
+      </div>
     );
   }
 
@@ -113,9 +121,7 @@ class ProfileAvatar extends React.Component {
     return (
       <div className="profile-avatar-wrap position-relative">
         <div className="profile-avatar rounded-circle bg-dark">
-          <div className="profile-avatar-menu-container">
-            {this.props.savePhotoState === 'pending' ? this.renderPending() : this.renderMenu() }
-          </div>
+          {this.props.savePhotoState === 'pending' ? this.renderPending() : this.renderMenu() }
           <img
             className="w-100 h-100 d-block rounded-circle overflow-hidden"
             style={{ objectFit: 'cover' }}

--- a/src/components/ProfilePage/ProfileAvatar.jsx
+++ b/src/components/ProfilePage/ProfileAvatar.jsx
@@ -57,62 +57,62 @@ class ProfileAvatar extends React.Component {
     );
   }
 
-  renderMenu() {
-    if (!this.props.isEditable) return null;
+  renderMenuContent() {
+    if (this.props.isDefault) {
+      return (
+        <Button
+          className="text-white btn-block"
+          color="link"
+          size="sm"
+          onClick={this.onClickUpload}
+        >
+          <FormattedMessage
+            id="profile.profileavatar.upload-button"
+            defaultMessage="Upload Photo"
+            description="Upload photo button"
+          />
+        </Button>
+      );
+    }
 
-    const menuContent = ((isDefault) => {
-      if (isDefault) {
-        return (
-          <Button
-            className="text-white btn-block"
-            color="link"
-            size="sm"
-            onClick={this.onClickUpload}
-          >
+    return (
+      <Dropdown
+        isOpen={this.state.dropdownOpen}
+        toggle={this.toggleDropdown}
+      >
+        <DropdownToggle className="text-white btn-block" color="link" size="sm">
+          <FormattedMessage
+            id="profile.profileavatar.change-button"
+            defaultMessage="Change"
+            description="Change photo button"
+          />
+        </DropdownToggle>
+        <DropdownMenu>
+          <DropdownItem onClick={this.onClickUpload}>
             <FormattedMessage
               id="profile.profileavatar.upload-button"
               defaultMessage="Upload Photo"
               description="Upload photo button"
             />
-          </Button>
-        );
-      }
-
-      return (
-        <Dropdown
-          isOpen={this.state.dropdownOpen}
-          toggle={this.toggleDropdown}
-        >
-          <DropdownToggle className="text-white btn-block" color="link" size="sm">
+          </DropdownItem>
+          <DropdownItem onClick={this.onClickDelete}>
             <FormattedMessage
-              id="profile.profileavatar.change-button"
-              defaultMessage="Change"
-              description="Change photo button"
+              id="profile.profileavatar.remove.button"
+              defaultMessage="Remove"
+              description="Remove photo button"
             />
-          </DropdownToggle>
-          <DropdownMenu>
-            <DropdownItem onClick={this.onClickUpload}>
-              <FormattedMessage
-                id="profile.profileavatar.upload-button"
-                defaultMessage="Upload Photo"
-                description="Upload photo button"
-              />
-            </DropdownItem>
-            <DropdownItem onClick={this.onClickDelete}>
-              <FormattedMessage
-                id="profile.profileavatar.remove.button"
-                defaultMessage="Remove"
-                description="Remove photo button"
-              />
-            </DropdownItem>
-          </DropdownMenu>
-        </Dropdown>
-      );
-    })(this.props.isDefault);
+          </DropdownItem>
+        </DropdownMenu>
+      </Dropdown>
+    );
+  }
+
+  renderMenu() {
+    if (!this.props.isEditable) return null;
 
     return (
       <div className="profile-avatar-menu-container">
-        {menuContent}
+        {this.renderMenuContent()}
       </div>
     );
   }

--- a/src/reducers/ProfilePageReducer.js
+++ b/src/reducers/ProfilePageReducer.js
@@ -28,7 +28,10 @@ const profilePage = (state = initialState, action) => {
     case FETCH_PROFILE.BEGIN:
       return {
         ...state,
-        isLoadingProfile: true,
+        // TODO: uncomment this line after ARCH-438 Image Post API returns the url
+        // is complete. Right now we refetch the whole profile causing us to show a full reload
+        // instead of a partial one.
+        // isLoadingProfile: true,
       };
     case FETCH_PROFILE.SUCCESS:
       return {


### PR DESCRIPTION
Also removes flipping the isLoadingProfile state when fetching a profile begins.

Desired behavior: Any time a whole profile is being loaded show the loading state. 

Right now the upload photo endpoint doesn't return the url we need so we refetch the whole profile again. This causes the whole page to appear to reload.

For now removing the resetting of isLoadingProfile to true inside FETCH_PROFILE.BEGIN will mean that isLoadingProfile is only true when the app first loads (it is the default state). We can uncomment this line in the future when we update the upload profile endpoint.