### PR TITLE
Shut off name editing and tweak visibility spacing

### DIFF
--- a/src/components/ProfilePage/Name.jsx
+++ b/src/components/ProfilePage/Name.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Form, FormFeedback, FormGroup, FormText, Input, Label } from 'reactstrap';
+import { Form, FormFeedback, FormGroup, FormText, Label } from 'reactstrap';
 import { connect } from 'react-redux';
 import { injectIntl, intlShape } from 'react-intl';
 
@@ -63,15 +63,15 @@ class Name extends React.Component {
                   <Label for="name" id={`${formId}-label`}>
                     {intl.formatMessage(messages['profile.name.full.name'])}
                   </Label>
-                  <Input
-                    type="text"
-                    id={formId}
-                    name={formId}
-                    value={name}
-                    invalid={error != null}
-                    onChange={this.handleChange}
-                    aria-describedby={`${formId}-error-feedback ${formId}-help-text`}
-                  />
+                  {/*
+                  This isn't a mistake - the name field should not be editable.  But if it were,
+                  you'd find the original code got deleted in the commit which added this comment.
+                  -djoy
+                  TODO: Relatedly, the plumbing for editing the name field is still in place.
+                  Once we're super sure we don't want it back, you could delete the name props and
+                  such to fully get rid of it.
+                  */}
+                  <p className="h5">{name}</p>
                   <FormText id={`${formId}-help-text`}>
                     {intl.formatMessage(messages['profile.name.details'])}
                   </FormText>

--- a/src/components/ProfilePage/elements/Visibility.jsx
+++ b/src/components/ProfilePage/elements/Visibility.jsx
@@ -38,7 +38,7 @@ function VisibilitySelect({ intl, className, ...props }) {
 
   return (
     <span className={className}>
-      <span className="d-inline-block mr-2" style={{ width: '1.5rem' }}>
+      <span className="d-inline-block ml-1 mr-2" style={{ width: '1.5rem' }}>
         <FontAwesomeIcon icon={icon} />
       </span>
       <Input className="d-inline-block w-auto" {...props} type="select">


### PR DESCRIPTION
As per @nasthagiri, shutting off name editing.

Also fixing a layout ugliness I noticed in the visibility.  The eyeball icon was a little too cozy with the text label.