### PR TITLE
fix: use lodash.get to provide default message ids to intl.formatMessage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9392,8 +9392,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -9414,14 +9413,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -9436,20 +9433,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -9566,8 +9560,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -9579,7 +9572,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -9594,7 +9586,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -9602,14 +9593,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -9628,7 +9617,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -9709,8 +9697,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -9722,7 +9709,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -9808,8 +9794,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -9845,7 +9830,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -9865,7 +9849,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -9909,14 +9892,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -12918,6 +12899,11 @@
       "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
       "integrity": "sha1-+wMJF/hqMTTlvJvsDWngAT3f7bI=",
       "dev": true
+    },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
     "lodash.isequal": {
       "version": "4.5.0",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "i18n-iso-countries": "^3.7.8",
     "iso-countries-languages": "^0.2.1",
     "lodash.camelcase": "^4.3.0",
+    "lodash.get": "^4.4.2",
     "lodash.snakecase": "^4.1.1",
     "newrelic": "^5.5.0",
     "prop-types": "^15.5.10",

--- a/src/components/ProfilePage/Certificates.jsx
+++ b/src/components/ProfilePage/Certificates.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { injectIntl, intlShape, FormattedMessage } from 'react-intl';
 import { Row, Col, Card, CardBody, CardTitle, Button, Form } from 'reactstrap';
 import { connect } from 'react-redux';
+import get from 'lodash.get';
 
 import messages from './Certificates.messages';
 
@@ -74,7 +75,11 @@ class Certificates extends React.Component {
           <CardBody className="d-flex flex-column">
             <CardTitle>
               <p className="small mb-0">
-                {intl.formatMessage(messages[`profile.certificates.types.${certificateType}`])}
+                {intl.formatMessage(get(
+                  messages,
+                  `profile.certificates.types.${certificateType}`,
+                  messages['profile.certificates.types.verified'],
+                ))}
               </p>
               <h4 className="certificate-title">{courseDisplayName}</h4>
             </CardTitle>

--- a/src/components/ProfilePage/Education.jsx
+++ b/src/components/ProfilePage/Education.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Form, FormFeedback, FormGroup, Input, Label } from 'reactstrap';
 import { connect } from 'react-redux';
 import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
+import get from 'lodash.get';
 
 import messages from './Education.messages';
 
@@ -77,7 +78,13 @@ class Education extends React.Component {
                     aria-describedby={`${formId}-error-feedback`}
                   >
                     {EDUCATION_LEVELS.map(level => (
-                      <option key={level} value={level}>{intl.formatMessage(messages[`profile.education.levels.${level}`])}</option>
+                      <option key={level} value={level}>
+                        {intl.formatMessage(get(
+                          messages,
+                          `profile.education.levels.${level}`,
+                          messages['profile.education.levels.o'],
+                        ))}
+                      </option>
                     ))}
                   </Input>
                   <FormFeedback id={`${formId}-error-feedback`}>{error}</FormFeedback>
@@ -101,7 +108,13 @@ class Education extends React.Component {
                 showVisibility={visibilityEducation !== null}
                 visibility={visibilityEducation}
               />
-              <p className="h5">{intl.formatMessage(messages[`profile.education.levels.${education}`])}</p>
+              <p className="h5">
+                {intl.formatMessage(get(
+                  messages,
+                  `profile.education.levels.${education}`,
+                  messages['profile.education.levels.o'],
+                ))}
+              </p>
             </React.Fragment>
           ),
           empty: (
@@ -119,7 +132,13 @@ class Education extends React.Component {
           static: (
             <React.Fragment>
               <EditableItemHeader content={intl.formatMessage(messages['profile.education.education'])} />
-              <p className="h5">{intl.formatMessage(messages[`profile.education.levels.${education}`])}</p>
+              <p className="h5">
+                {intl.formatMessage(get(
+                  messages,
+                  `profile.education.levels.${education}`,
+                  messages['profile.education.levels.o'],
+                ))}
+              </p>
             </React.Fragment>
           ),
         }}


### PR DESCRIPTION
intl.formatMessage will error out if it's provided a message id that doesn't exist. This PR adds default ids to certificate and education level strings.