### PR TITLE
drop fork of html-webpack-new-relic-plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11582,8 +11582,9 @@
       }
     },
     "html-webpack-new-relic-plugin": {
-      "version": "git+https://git@github.com/edx/html-webpack-new-relic-plugin.git#e7204801b9484faa38b448bef3e6a8a3bfa05b6b",
-      "from": "git+https://git@github.com/edx/html-webpack-new-relic-plugin.git#e7204801b9484faa38b448bef3e6a8a3bfa05b6b",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/html-webpack-new-relic-plugin/-/html-webpack-new-relic-plugin-1.1.0.tgz",
+      "integrity": "sha512-4eYER/YsIAzBIiG0ooxICzJN9Z85mvWvlGxKgM8mVtnEGYTMmFZ6Lcy82Yoi/nnpT4tMJXaTWz27iZp+HN7IPA==",
       "dev": true,
       "requires": {
         "cheerio": "^1.0.0-rc.2"

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "fetch-mock": "^6.3.0",
     "file-loader": "^1.1.9",
     "html-webpack-harddisk-plugin": "^0.2.0",
-    "html-webpack-new-relic-plugin": "git+https://git@github.com/edx/html-webpack-new-relic-plugin.git#e7204801b9484faa38b448bef3e6a8a3bfa05b6b",
+    "html-webpack-new-relic-plugin": "^1.1.0",
     "html-webpack-plugin": "^3.0.3",
     "husky": "^0.14.3",
     "identity-obj-proxy": "^3.0.0",


### PR DESCRIPTION
The update to NewRelic snippet was merged upstream, so we can now use
the upstream version again.