### PR TITLE
fix: handle focus control better for opening and closing forms.

### DIFF
--- a/src/components/ProfilePage/elements/FormControls.jsx
+++ b/src/components/ProfilePage/elements/FormControls.jsx
@@ -38,6 +38,17 @@ function FormControls({
             pending: intl.formatMessage(messages['profile.formcontrols.button.saving']),
             complete: intl.formatMessage(messages['profile.formcontrols.button.saved']),
           }}
+          onClick={(e) => {
+            // Swallow clicks if the state is pending.
+            // We do this instead of disabling the button to prevent
+            // it from losing focus (disabled elements cannot have focus).
+            // Disabling it would causes upstream issues in focus management.
+            // Swallowing the onSubmit event on the form would be better, but
+            // we would have to add that logic for every field given our
+            // current structure of the application.
+            if (buttonState === 'pending') e.preventDefault();
+          }}
+          disabledStates={[]}
         />
         <Button className="btn-link" onClick={cancelHandler}>
           {intl.formatMessage(messages['profile.formcontrols.button.cancel'])}

--- a/src/components/ProfilePage/elements/SwitchContent.jsx
+++ b/src/components/ProfilePage/elements/SwitchContent.jsx
@@ -3,16 +3,21 @@ import PropTypes from 'prop-types';
 import { TransitionReplace } from '@edx/paragon';
 
 
-const onChildEntered = (htmlNode) => {
-  const focusableElements = htmlNode.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
-  if (focusableElements.length) {
-    focusableElements[0].focus();
-  }
-};
-
 const onChildExit = (htmlNode) => {
+  // If the leaving child has focus, take control and redirect it
   if (htmlNode.contains(document.activeElement)) {
-    document.activeElement.blur();
+    // Get the newly entering sibling.
+    // It's the previousSibling, but not for any explicit reason. So checking for both.
+    const enteringChild = htmlNode.previousSibling || htmlNode.nextSibling;
+
+    // There's no replacement, do nothing.
+    if (!enteringChild) return;
+
+    // Get all the focusable elements in the entering child and focus the first one
+    const focusableElements = enteringChild.querySelectorAll('button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])');
+    if (focusableElements.length) {
+      focusableElements[0].focus();
+    }
   }
 };
 
@@ -37,7 +42,6 @@ function SwitchContent({ expression, cases, className }) {
   return (
     <TransitionReplace
       className={className}
-      onChildEntered={onChildEntered}
       onChildExit={onChildExit}
     >
       {getContent(expression)}
@@ -48,7 +52,7 @@ function SwitchContent({ expression, cases, className }) {
 
 SwitchContent.propTypes = {
   expression: PropTypes.string,
-  cases: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
+  cases: PropTypes.objectOf(PropTypes.node).isRequired,
   className: PropTypes.string,
 };
 

--- a/src/components/__snapshots__/ProfilePage.test.jsx.snap
+++ b/src/components/__snapshots__/ProfilePage.test.jsx.snap
@@ -2064,8 +2064,8 @@ exports[`<ProfilePage /> Renders correctly in various states while saving an edi
                   >
                     <button
                       aria-live="assertive"
-                      className="btn pgn__stateful-btn pgn__stateful-btn-state-pending btn-primary disabled"
-                      disabled={true}
+                      className="btn pgn__stateful-btn pgn__stateful-btn-state-pending btn-primary"
+                      disabled={false}
                       onBlur={[Function]}
                       onClick={[Function]}
                       onKeyDown={[Function]}


### PR DESCRIPTION
Opening and closing a form now redirects focus only if its child currently has the active (focused) element.

This change prevents focus issues when opening a form while another is already open where you could not guarantee focus would be in the desired place (the first element of the new content the user has opened).