### PR TITLE
Compare the right usernames.

### DIFF
--- a/src/sagas/RootSaga.js
+++ b/src/sagas/RootSaga.js
@@ -38,7 +38,7 @@ import { keepKeys } from '../services/utils';
 
 export function* handleFetchProfile(action) {
   const { username } = action.payload;
-  const { isAuthenticatedUserProfile, userAccount } = yield select(handleFetchProfileSelector);
+  const { authenticationUsername, userAccount } = yield select(handleFetchProfileSelector);
 
   // Default our data assuming the account is the current user's account.
   let preferences = {};
@@ -54,7 +54,7 @@ export function* handleFetchProfile(action) {
       call(ProfileApiService.getCourseCertificates, username),
     ];
 
-    if (isAuthenticatedUserProfile) {
+    if (username === authenticationUsername) {
       // If the profile is for the current user, get their preferences.
       // We don't need them for other users.
       calls.push(call(ProfileApiService.getPreferences, username));
@@ -67,7 +67,7 @@ export function* handleFetchProfile(action) {
     // Make all the calls in parallel.
     const result = yield all(calls);
 
-    if (isAuthenticatedUserProfile) {
+    if (username === authenticationUsername) {
       [courseCertificates, preferences] = result;
     } else {
       [courseCertificates, account] = result;

--- a/src/sagas/RootSaga.test.js
+++ b/src/sagas/RootSaga.test.js
@@ -49,7 +49,7 @@ describe('RootSaga', () => {
         other: 'data',
       };
       const selectorData = {
-        isAuthenticatedUserProfile: true,
+        authenticationUsername: 'gonzo',
         userAccount,
       };
 
@@ -76,7 +76,7 @@ describe('RootSaga', () => {
         other: 'data',
       };
       const selectorData = {
-        isAuthenticatedUserProfile: false,
+        authenticationUsername: 'gonzo',
         userAccount,
       };
 

--- a/src/selectors/ProfilePageSelector.js
+++ b/src/selectors/ProfilePageSelector.js
@@ -166,10 +166,10 @@ export const handleSaveProfileSelector = createSelector(
 );
 
 export const handleFetchProfileSelector = createSelector(
-  isAuthenticatedUserProfileSelector,
+  authenticationUsernameSelector,
   userAccountSelector,
-  (isAuthenticatedUserProfile, userAccount) => ({
-    isAuthenticatedUserProfile,
+  (authenticationUsername, userAccount) => ({
+    authenticationUsername,
     userAccount,
   }),
 );


### PR DESCRIPTION
We can’t use isAuthenticatedUserProfileSelector before we’ve actually loaded the profile - the username will be null.  Instead, we want to compare the username of the profile we’re supposed to load with the username in the authentication part of the store.