### PR TITLE
Redirect to error page on fetch user account failure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2561,9 +2561,9 @@
       }
     },
     "@edx/frontend-auth": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-auth/-/frontend-auth-3.1.0.tgz",
-      "integrity": "sha512-GA+TFrxdb1bRtVuPheL0n+SRdXsK+V08DFgdHdzprg2e4/1q7gDcDigyO0VqClIAcTsk/MtgOPnWRF8UZ7NMgw==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-auth/-/frontend-auth-3.2.0.tgz",
+      "integrity": "sha512-FwOVde6/ZZWT5ZKe6pRqwR+TAV6ARjSTvDF/lt2EcIEyjG/ydRuC/QRYlamnSuODPqhq+414yKWGx4UvFWlxSw==",
       "requires": {
         "axios": "^0.18.0",
         "camelcase-keys": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "@cospired/i18n-iso-languages": "^2.0.2",
     "@edx/edx-bootstrap": "git://github.com/edx/edx-bootstrap.git#update-with-documentation-site",
-    "@edx/frontend-auth": "^3.1.0",
+    "@edx/frontend-auth": "^3.2.0",
     "@edx/frontend-component-footer": "^2.0.3",
     "@edx/frontend-component-site-header": "^2.1.4",
     "@edx/frontend-logging": "^1.0.0",

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -26,7 +26,7 @@ class App extends Component {
   }
 
   renderContent() {
-    if (!this.props.loaded) {
+    if (!this.props.ready) {
       return <PageLoading />;
     }
 
@@ -82,16 +82,18 @@ App.propTypes = {
   username: PropTypes.string.isRequired,
   store: PropTypes.object.isRequired, // eslint-disable-line
   history: PropTypes.object.isRequired, // eslint-disable-line
-  loaded: PropTypes.bool,
+  ready: PropTypes.bool,
 };
 
 App.defaultProps = {
-  loaded: false,
+  ready: false,
 };
 
 const mapStateToProps = state => ({
   username: state.authentication.username,
-  loaded: state.userAccount.loaded,
+  // An error means that we tried to load the user account and failed,
+  // which also means we're ready to display something.
+  ready: state.userAccount.loaded || state.userAccount.error != null,
 });
 
 export default connect(

--- a/src/sagas/RootSaga.js
+++ b/src/sagas/RootSaga.js
@@ -1,6 +1,7 @@
 import { push } from 'connected-react-router';
 import { all, call, delay, put, select, takeEvery } from 'redux-saga/effects';
 import LoggingService from '@edx/frontend-logging';
+import { FETCH_USER_ACCOUNT_FAILURE } from '@edx/frontend-auth';
 
 // Actions
 import {
@@ -191,9 +192,15 @@ export function* handleDeleteProfilePhoto(action) {
   }
 }
 
+export function* handleFetchUserAccountFailure(action) {
+  LoggingService.logAPIErrorResponse(action.payload.error);
+  yield put(push('/error'));
+}
+
 export default function* rootSaga() {
   yield takeEvery(FETCH_PROFILE.BASE, handleFetchProfile);
   yield takeEvery(SAVE_PROFILE.BASE, handleSaveProfile);
   yield takeEvery(SAVE_PROFILE_PHOTO.BASE, handleSaveProfilePhoto);
   yield takeEvery(DELETE_PROFILE_PHOTO.BASE, handleDeleteProfilePhoto);
+  yield takeEvery(FETCH_USER_ACCOUNT_FAILURE, handleFetchUserAccountFailure);
 }

--- a/src/sagas/RootSaga.test.js
+++ b/src/sagas/RootSaga.test.js
@@ -1,4 +1,5 @@
 import { takeEvery, put, call, delay, select, all } from 'redux-saga/effects';
+import { FETCH_USER_ACCOUNT_FAILURE } from '@edx/frontend-auth';
 
 import * as profileActions from '../actions/ProfileActions';
 import { handleSaveProfileSelector, handleFetchProfileSelector } from '../selectors/ProfilePageSelector';
@@ -20,6 +21,7 @@ import rootSaga, {
   handleSaveProfile,
   handleSaveProfilePhoto,
   handleDeleteProfilePhoto,
+  handleFetchUserAccountFailure,
 } from './RootSaga';
 import * as ProfileApiService from '../services/ProfileApiService';
 /* eslint-enable import/first */
@@ -37,6 +39,8 @@ describe('RootSaga', () => {
         .toEqual(takeEvery(profileActions.SAVE_PROFILE_PHOTO.BASE, handleSaveProfilePhoto));
       expect(gen.next().value)
         .toEqual(takeEvery(profileActions.DELETE_PROFILE_PHOTO.BASE, handleDeleteProfilePhoto));
+      expect(gen.next().value)
+        .toEqual(takeEvery(FETCH_USER_ACCOUNT_FAILURE, handleFetchUserAccountFailure));
 
       expect(gen.next().value).toBeUndefined();
     });


### PR DESCRIPTION
If the fetchUserAccount action results in a failure of some sort, redirect to the error page.  

This PR relied on exporting the fetch user account action types from frontend-auth, thus the bump there.