### PR TITLE
fix: get two letter language code from cookie

### DIFF
--- a/src/i18n/i18n-loader.js
+++ b/src/i18n/i18n-loader.js
@@ -65,7 +65,7 @@ const getLocale = (localeStr) => {
   // 2. User setting in cookie
   const cookieLanguagePreference = cookies.get(process.env.LANGUAGE_PREFERENCE_COOKIE_NAME);
   if (cookieLanguagePreference && messages[cookieLanguagePreference] !== undefined) {
-    return cookieLanguagePreference;
+    return cookieLanguagePreference.substr(0, 2);
   }
   // 3. Browser language (default)
   return window.navigator.language.substr(0, 2);


### PR DESCRIPTION
Can now handle values like `es-415` in the cookie