### PR TITLE
fix: get profile photo changes from calls back into redux store

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10407,8 +10407,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -10429,14 +10428,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -10451,20 +10448,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -10581,8 +10575,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -10594,7 +10587,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -10609,7 +10601,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -10617,14 +10608,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -10643,7 +10632,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -10724,8 +10712,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -10737,7 +10724,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -10823,8 +10809,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -10860,7 +10845,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -10880,7 +10864,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -10924,14 +10907,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/src/actions/ProfileActions.js
+++ b/src/actions/ProfileActions.js
@@ -75,8 +75,9 @@ export const saveProfilePhotoBegin = () => ({
   type: SAVE_PROFILE_PHOTO.BEGIN,
 });
 
-export const saveProfilePhotoSuccess = () => ({
+export const saveProfilePhotoSuccess = profileImage => ({
   type: SAVE_PROFILE_PHOTO.SUCCESS,
+  payload: { profileImage },
 });
 
 export const saveProfilePhotoReset = () => ({
@@ -101,8 +102,9 @@ export const deleteProfilePhotoBegin = () => ({
   type: DELETE_PROFILE_PHOTO.BEGIN,
 });
 
-export const deleteProfilePhotoSuccess = () => ({
+export const deleteProfilePhotoSuccess = profileImage => ({
   type: DELETE_PROFILE_PHOTO.SUCCESS,
+  payload: { profileImage },
 });
 
 export const deleteProfilePhotoReset = () => ({

--- a/src/actions/ProfileActions.test.js
+++ b/src/actions/ProfileActions.test.js
@@ -114,10 +114,14 @@ describe('SAVE profile photo actions', () => {
   });
 
   it('should create an action to signal user profile photo save success', () => {
+    const newPhotoData = { hasImage: true };
     const expectedAction = {
       type: SAVE_PROFILE_PHOTO.SUCCESS,
+      payload: {
+        profileImage: newPhotoData,
+      },
     };
-    expect(saveProfilePhotoSuccess()).toEqual(expectedAction);
+    expect(saveProfilePhotoSuccess(newPhotoData)).toEqual(expectedAction);
   });
 
   it('should create an action to signal user profile photo save success', () => {
@@ -157,10 +161,14 @@ describe('DELETE profile photo actions', () => {
   });
 
   it('should create an action to signal user profile photo deletion success', () => {
+    const defaultPhotoData = { hasImage: false };
     const expectedAction = {
       type: DELETE_PROFILE_PHOTO.SUCCESS,
+      payload: {
+        profileImage: defaultPhotoData,
+      },
     };
-    expect(deleteProfilePhotoSuccess()).toEqual(expectedAction);
+    expect(deleteProfilePhotoSuccess(defaultPhotoData)).toEqual(expectedAction);
   });
 
   it('should create an action to signal user profile photo deletion success', () => {

--- a/src/reducers/ProfilePageReducer.js
+++ b/src/reducers/ProfilePageReducer.js
@@ -79,7 +79,7 @@ const profilePage = (state = initialState, action) => {
     case SAVE_PROFILE_PHOTO.SUCCESS:
       return {
         ...state,
-        // Merged in new profile image data
+        // Merge in new profile image data
         account: Object.assign({}, state.account, { profileImage: action.payload.profileImage }),
         savePhotoState: 'complete',
         errors: {},
@@ -106,7 +106,7 @@ const profilePage = (state = initialState, action) => {
     case DELETE_PROFILE_PHOTO.SUCCESS:
       return {
         ...state,
-        // Merged in new profile image data (should be empty or default image)
+        // Merge in new profile image data (should be empty or default image)
         account: Object.assign({}, state.account, { profileImage: action.payload.profileImage }),
         savePhotoState: 'complete',
         errors: {},

--- a/src/reducers/ProfilePageReducer.js
+++ b/src/reducers/ProfilePageReducer.js
@@ -79,6 +79,8 @@ const profilePage = (state = initialState, action) => {
     case SAVE_PROFILE_PHOTO.SUCCESS:
       return {
         ...state,
+        // Merged in new profile image data
+        account: Object.assign({}, state.account, { profileImage: action.payload.profileImage }),
         savePhotoState: 'complete',
         errors: {},
       };
@@ -104,6 +106,8 @@ const profilePage = (state = initialState, action) => {
     case DELETE_PROFILE_PHOTO.SUCCESS:
       return {
         ...state,
+        // Merged in new profile image data (should be empty or default image)
+        account: Object.assign({}, state.account, { profileImage: action.payload.profileImage }),
         savePhotoState: 'complete',
         errors: {},
       };

--- a/src/sagas/RootSaga.js
+++ b/src/sagas/RootSaga.js
@@ -9,7 +9,6 @@ import {
   fetchProfileBegin,
   fetchProfileSuccess,
   fetchProfileReset,
-  fetchProfile,
   SAVE_PROFILE,
   saveProfileBegin,
   saveProfileSuccess,
@@ -155,12 +154,8 @@ export function* handleSaveProfilePhoto(action) {
 
   try {
     yield put(saveProfilePhotoBegin());
-    yield call(ProfileApiService.postProfilePhoto, username, formData);
-
-    // Get the account data. Saving doesn't return anything on success.
-    yield handleFetchProfile(fetchProfile(username));
-
-    yield put(saveProfilePhotoSuccess());
+    const photoResult = yield call(ProfileApiService.postProfilePhoto, username, formData);
+    yield put(saveProfilePhotoSuccess(photoResult));
     yield put(saveProfilePhotoReset());
   } catch (e) {
     if (e.processedData) {
@@ -178,12 +173,8 @@ export function* handleDeleteProfilePhoto(action) {
 
   try {
     yield put(deleteProfilePhotoBegin());
-    yield call(ProfileApiService.deleteProfilePhoto, username);
-
-    // Get the account data. Saving doesn't return anything on success.
-    yield handleFetchProfile(fetchProfile(username));
-
-    yield put(deleteProfilePhotoSuccess());
+    const photoResult = yield call(ProfileApiService.deleteProfilePhoto, username);
+    yield put(deleteProfilePhotoSuccess(photoResult));
     yield put(deleteProfilePhotoReset());
   } catch (e) {
     LoggingService.logAPIErrorResponse(e);

--- a/src/services/ProfileApiService.js
+++ b/src/services/ProfileApiService.js
@@ -53,6 +53,7 @@ export async function patchProfile(username, params) {
 // POST PROFILE PHOTO
 
 export async function postProfilePhoto(username, formData) {
+  // eslint-disable-next-line no-unused-vars
   const { data } = await apiClient.post(
     `${configuration.ACCOUNTS_API_BASE_URL}/${username}/image`,
     formData,
@@ -65,14 +66,28 @@ export async function postProfilePhoto(username, formData) {
     processAndThrowError(error, camelCaseObject);
   });
 
-  return camelCaseObject(data);
+  // TODO: Someday in the future the POST photo endpoint
+  // will return the new values. At that time we should
+  // use the commented line below instead of the separate
+  // getAccount request that follows.
+  // return camelCaseObject(data);
+  const updatedData = await getAccount(username);
+  return updatedData.profileImage;
 }
 
 // DELETE PROFILE PHOTO
 
 export async function deleteProfilePhoto(username) {
+  // eslint-disable-next-line no-unused-vars
   const { data } = await apiClient.delete(`${configuration.ACCOUNTS_API_BASE_URL}/${username}/image`);
-  return camelCaseObject(data);
+
+  // TODO: Someday in the future the POST photo endpoint
+  // will return the new values. At that time we should
+  // use the commented line below instead of the separate
+  // getAccount request that follows.
+  // return camelCaseObject(data);
+  const updatedData = await getAccount(username);
+  return updatedData.profileImage;
 }
 
 // GET PREFERENCES


### PR DESCRIPTION
Fixes bug: Uploaded photos on the profile page do successfully upload and update, but changes are not reflected until refreshing the page.

To reduce api calls we removed the refetching of user profile data. This is fine for other fields because they receive the newly set values from the server in their post/patch requests. The photo upload doesn't do this and needs to refetch the profile data. This was done by firing the fetchProfile action (which now doesn't refetch the user's data). 

To solve this the API service functions `postProfilePhoto` and `deleteProfilePhoto` now call `getAccount` directly. They now return the new/updated photo data themselves. This matches what should happen in the future when the POST profile endpoint returns updated values on success.
