### PR TITLE
fix: make intl.formatMessage more resilient

### DIFF
--- a/config/webpack.common.config.js
+++ b/config/webpack.common.config.js
@@ -12,5 +12,8 @@ module.exports = {
   },
   resolve: {
     extensions: ['.js', '.jsx'],
+    alias: {
+      '@edx/frontend-i18n': path.resolve(__dirname, '../src/i18n/'),
+    },
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -10407,8 +10407,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -10429,14 +10428,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -10451,20 +10448,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -10581,8 +10575,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -10594,7 +10587,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -10609,7 +10601,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -10617,14 +10608,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -10643,7 +10632,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -10724,8 +10712,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -10737,7 +10724,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -10823,8 +10809,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -10860,7 +10845,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -10880,7 +10864,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -10924,14 +10907,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -125,7 +125,8 @@
     "moduleNameMapper": {
       "\\.svg": "<rootDir>/__mocks__/svgrMock.js",
       "\\.(jpg|jpeg|png|gif|eot|otf|webp|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
-      "\\.(css|scss)$": "identity-obj-proxy"
+      "\\.(css|scss)$": "identity-obj-proxy",
+      "@edx/frontend-i18n(.*)$": "<rootDir>/src/i18n$1"
     },
     "collectCoverageFrom": [
       "src/**/*.{js,jsx}"

--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -9,7 +9,7 @@ import SiteFooter from '@edx/frontend-component-footer';
 import { fetchUserAccount, UserAccountApiService } from '@edx/frontend-auth';
 
 import apiClient from '../config/apiClient';
-import { getLocale, getMessages } from '../i18n/i18n-loader';
+import { getLocale, getMessages } from '@edx/frontend-i18n'; // eslint-disable-line
 import SiteHeader from './common/SiteHeader';
 import ConnectedProfilePage from './ProfilePage';
 

--- a/src/components/ProfilePage.jsx
+++ b/src/components/ProfilePage.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { StatusAlert, Hyperlink } from '@edx/paragon';
 import { connect } from 'react-redux';
-import { injectIntl, intlShape } from 'react-intl';
+import { injectIntl, intlShape } from '@edx/frontend-i18n'; // eslint-disable-line
 
 // Analytics
 import { sendTrackingLogEvent } from '@edx/frontend-analytics';

--- a/src/components/ProfilePage/Bio.jsx
+++ b/src/components/ProfilePage/Bio.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { injectIntl, intlShape, FormattedMessage } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
+import { injectIntl, intlShape } from '@edx/frontend-i18n'; // eslint-disable-line
 import { ValidationFormGroup } from '@edx/paragon';
 
 import messages from './Bio.messages';

--- a/src/components/ProfilePage/Certificates.jsx
+++ b/src/components/ProfilePage/Certificates.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { injectIntl, intlShape, FormattedDate, FormattedMessage } from 'react-intl';
+import { FormattedDate, FormattedMessage } from 'react-intl';
+import { injectIntl, intlShape } from '@edx/frontend-i18n'; // eslint-disable-line
 import { Hyperlink } from '@edx/paragon';
 import { connect } from 'react-redux';
 import get from 'lodash.get';

--- a/src/components/ProfilePage/Country.jsx
+++ b/src/components/ProfilePage/Country.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { injectIntl, intlShape } from 'react-intl';
+import { injectIntl, intlShape } from '@edx/frontend-i18n'; // eslint-disable-line
 import { ValidationFormGroup } from '@edx/paragon';
 
 import messages from './Country.messages';

--- a/src/components/ProfilePage/Education.jsx
+++ b/src/components/ProfilePage/Education.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
+import { injectIntl, intlShape } from '@edx/frontend-i18n'; // eslint-disable-line
 import get from 'lodash.get';
 import { ValidationFormGroup } from '@edx/paragon';
 

--- a/src/components/ProfilePage/Name.jsx
+++ b/src/components/ProfilePage/Name.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { injectIntl, intlShape } from 'react-intl';
+import { injectIntl, intlShape } from '@edx/frontend-i18n'; // eslint-disable-line
 
 import messages from './Name.messages';
 

--- a/src/components/ProfilePage/PreferredLanguage.jsx
+++ b/src/components/ProfilePage/PreferredLanguage.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
-import { injectIntl, intlShape } from 'react-intl';
+import { injectIntl, intlShape } from '@edx/frontend-i18n'; // eslint-disable-line
 import { ValidationFormGroup } from '@edx/paragon';
 
 import messages from './PreferredLanguage.messages';

--- a/src/components/ProfilePage/ProfileAvatar.jsx
+++ b/src/components/ProfilePage/ProfileAvatar.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Button, Dropdown } from '@edx/paragon';
-import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
+import { injectIntl, intlShape } from '@edx/frontend-i18n'; // eslint-disable-line
 
 import { ReactComponent as DefaultAvatar } from '../../assets/avatar.svg';
 

--- a/src/components/ProfilePage/SocialLinks.jsx
+++ b/src/components/ProfilePage/SocialLinks.jsx
@@ -4,7 +4,8 @@ import { StatusAlert } from '@edx/paragon';
 import { connect } from 'react-redux';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faTwitter, faFacebook, faLinkedin } from '@fortawesome/free-brands-svg-icons';
-import { injectIntl, intlShape, FormattedMessage } from 'react-intl';
+import { FormattedMessage } from 'react-intl';
+import { injectIntl, intlShape } from '@edx/frontend-i18n'; // eslint-disable-line
 import classNames from 'classnames';
 
 import messages from './SocialLinks.messages';

--- a/src/components/ProfilePage/elements/EditButton.jsx
+++ b/src/components/ProfilePage/elements/EditButton.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faPencilAlt } from '@fortawesome/free-solid-svg-icons';
-import { injectIntl, intlShape } from 'react-intl';
+import { injectIntl, intlShape } from '@edx/frontend-i18n'; // eslint-disable-line
 import { Button } from '@edx/paragon';
 
 import messages from './EditButton.messages';

--- a/src/components/ProfilePage/elements/FormControls.jsx
+++ b/src/components/ProfilePage/elements/FormControls.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Button, StatefulButton } from '@edx/paragon';
-import { injectIntl, intlShape } from 'react-intl';
+import { injectIntl, intlShape } from '@edx/frontend-i18n'; // eslint-disable-line
 
 import messages from './FormControls.messages';
 

--- a/src/components/ProfilePage/elements/Visibility.jsx
+++ b/src/components/ProfilePage/elements/Visibility.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { injectIntl, intlShape } from 'react-intl';
+import { injectIntl, intlShape } from '@edx/frontend-i18n'; // eslint-disable-line
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { faEyeSlash, faEye } from '@fortawesome/free-regular-svg-icons';
 

--- a/src/components/common/SiteHeader.jsx
+++ b/src/components/common/SiteHeader.jsx
@@ -1,6 +1,6 @@
 import { connect } from 'react-redux';
 import SiteHeader from '@edx/frontend-component-site-header';
-import { injectIntl } from 'react-intl';
+import { injectIntl } from '@edx/frontend-i18n'; // eslint-disable-line
 
 import messages from './SiteHeader.messages';
 

--- a/src/i18n/index.jsx
+++ b/src/i18n/index.jsx
@@ -1,0 +1,8 @@
+import { intlShape } from 'react-intl';
+import injectIntlWithShim from './injectIntlWithShim';
+
+
+export {
+  injectIntlWithShim as injectIntl,
+  intlShape,
+};

--- a/src/i18n/index.jsx
+++ b/src/i18n/index.jsx
@@ -1,8 +1,25 @@
 import { intlShape } from 'react-intl';
 import injectIntlWithShim from './injectIntlWithShim';
-
+import {
+  getCountryList,
+  getCountryMessages,
+  getLanguageList,
+  getLanguageMessages,
+  getLocale,
+  getMessages,
+  handleRtl,
+  isRtl,
+} from './i18n-loader';
 
 export {
   injectIntlWithShim as injectIntl,
+  getCountryList,
+  getCountryMessages,
+  getLanguageList,
+  getLanguageMessages,
+  getLocale,
+  getMessages,
+  handleRtl,
+  isRtl,
   intlShape,
 };

--- a/src/i18n/injectIntlWithShim.jsx
+++ b/src/i18n/injectIntlWithShim.jsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { injectIntl, intlShape } from 'react-intl';
+
+
+const injectIntlWithShim = (WrappedComponent) => {
+  class ShimmedIntlComponent extends React.Component {
+    static propTypes = {
+      intl: intlShape.isRequired,
+    };
+
+    constructor(props) {
+      super(props);
+      this.shimmedIntl = Object.create(this.props.intl, {
+        formatMessage: {
+          value: (definition) => {
+            if (definition === undefined) {
+              if (process.env.NODE_ENV !== 'production') {
+                // eslint-disable-next-line no-console
+                console.error('i18n error: An undefined message was supplied to intl.formatMessage.');
+                return '!!! Missing message supplied to intl.formatMessage !!!';
+              }
+              return ''; // Fail silent in production
+            }
+            return this.props.intl.formatMessage(definition);
+          },
+        },
+      });
+    }
+
+    render() {
+      return <WrappedComponent {...this.props} intl={this.shimmedIntl} />;
+    }
+  }
+
+  return injectIntl(ShimmedIntlComponent);
+};
+
+
+export default injectIntlWithShim;

--- a/src/i18n/injectIntlWithShim.jsx
+++ b/src/i18n/injectIntlWithShim.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { injectIntl, intlShape } from 'react-intl';
+import LoggingService from '@edx/frontend-logging';
 
 
 const injectIntlWithShim = (WrappedComponent) => {
@@ -13,12 +14,13 @@ const injectIntlWithShim = (WrappedComponent) => {
       this.shimmedIntl = Object.create(this.props.intl, {
         formatMessage: {
           value: (definition) => {
-            if (definition === undefined) {
+            if (definition === undefined || definition.id === undefined) {
+              const error = new Error('i18n error: An undefined message was supplied to intl.formatMessage.');
               if (process.env.NODE_ENV !== 'production') {
-                // eslint-disable-next-line no-console
-                console.error('i18n error: An undefined message was supplied to intl.formatMessage.');
+                console.error(error); // eslint-disable-line no-console
                 return '!!! Missing message supplied to intl.formatMessage !!!';
               }
+              LoggingService.logError(error);
               return ''; // Fail silent in production
             }
             return this.props.intl.formatMessage(definition);

--- a/src/selectors/ProfilePageSelector.js
+++ b/src/selectors/ProfilePageSelector.js
@@ -1,5 +1,5 @@
 import { createSelector } from 'reselect';
-import { getLocale, getLanguageList, getCountryList, getCountryMessages, getLanguageMessages } from '../i18n/i18n-loader';
+import { getLocale, getLanguageList, getCountryList, getCountryMessages, getLanguageMessages } from '@edx/frontend-i18n'; // eslint-disable-line
 
 export const formIdSelector = (state, props) => props.formId;
 export const userAccountSelector = state => state.userAccount;


### PR DESCRIPTION
- Adds a shim replacement for injectIntl to override intl.formatMessage so it won't blow up when supplied an undefined message definition.
- Adds an index.js file to the i18n folder to start prepping it to be pulled out into a package
- Added an alias for @edx/frontend-i18n in the webpack config and jest config (package.json) to allow the rest of the code be written as if this package already existed.
 