### PR TITLE
ARCH-587: upgrade newrelic sourcemap dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11380,8 +11380,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -11402,14 +11401,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -11424,20 +11421,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -11554,8 +11548,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -11567,7 +11560,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -11582,7 +11574,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -11590,14 +11581,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -11616,7 +11605,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -11697,8 +11685,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -11710,7 +11697,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -11796,8 +11782,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -11833,7 +11818,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -11853,7 +11837,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -11897,14 +11880,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -15834,12 +15815,11 @@
       "dev": true
     },
     "new-relic-source-map-webpack-plugin": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/new-relic-source-map-webpack-plugin/-/new-relic-source-map-webpack-plugin-1.1.0.tgz",
-      "integrity": "sha512-evLeCEU6T2ir5ZWN79q2n9Rl94jv62O6XQvhl2vilsFDrUgDu5xzamwXQQtcvySE3gKcO34oozW1xFDp89IaMQ==",
+      "version": "git://github.com/robrap/new-relic-source-map-webpack-plugin.git#c254dfa48de567e43bbeb4389e623081e0674560",
+      "from": "git://github.com/robrap/new-relic-source-map-webpack-plugin.git#update-newrelic-plugin",
       "dev": true,
       "requires": {
-        "@newrelic/publish-sourcemap": "^4.1.2"
+        "@newrelic/publish-sourcemap": "^4.4.1"
       }
     },
     "newrelic": {

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "image-webpack-loader": "^4.2.0",
     "jest": "^22.4.0",
     "mini-css-extract-plugin": "^0.4.0",
-    "new-relic-source-map-webpack-plugin": "1.1.0",
+    "new-relic-source-map-webpack-plugin": "git://github.com/robrap/new-relic-source-map-webpack-plugin.git#update-newrelic-plugin",
     "node-sass": "^4.7.2",
     "postcss-loader": "^3.0.0",
     "react-dev-utils": "^5.0.0",


### PR DESCRIPTION
temporarily using a fork to determine how best to proceed.

ARCH-587

Although the Source Maps are loading into NewRelic, they aren't working correctly yet.  Since they aren't working properly, I want to discuss with NewRelic Support, but I imagine the first thing they will want to know is if we are using their latest library.  So, this makes use of their latest.