### PR TITLE
fix: delay closing a form on success so a user can read the message

### DIFF
--- a/src/profile/sagas.js
+++ b/src/profile/sagas.js
@@ -135,7 +135,7 @@ export function* handleSaveProfile(action) {
     // The preferences draft is valid if the server didn't complain, so
     // pass it through directly.
     yield put(saveProfileSuccess(accountResult, preferencesResult));
-    yield delay(300);
+    yield delay(1000);
     yield put(closeForm(action.payload.formId));
     yield delay(300);
     yield put(saveProfileReset());

--- a/src/profile/sagas.test.js
+++ b/src/profile/sagas.test.js
@@ -126,7 +126,7 @@ describe('RootSaga', () => {
       // The library would supply the result of the above call
       // as the parameter to the NEXT yield.  Here:
       expect(gen.next(profile).value).toEqual(put(profileActions.saveProfileSuccess(profile, {})));
-      expect(gen.next().value).toEqual(delay(300));
+      expect(gen.next().value).toEqual(delay(1000));
       expect(gen.next().value).toEqual(put(profileActions.closeForm('ze form id')));
       expect(gen.next().value).toEqual(delay(300));
       expect(gen.next().value).toEqual(put(profileActions.saveProfileReset()));


### PR DESCRIPTION
Wait for 1000ms instead of 300ms after successfully saving before closing a form