### PR TITLE
fix: upgrade frontend auth

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2587,9 +2587,9 @@
       }
     },
     "@edx/frontend-auth": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-auth/-/frontend-auth-5.0.0.tgz",
-      "integrity": "sha512-sBbmBStRxuzcfYmq0F+FQjRyMbvOr1y22rV1Hdg3V+AtkmLyK4NW1YZRVp2Nj+W8oaaQzJPI9CdrUjNdtmuHfA==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-auth/-/frontend-auth-5.1.1.tgz",
+      "integrity": "sha512-bkPTzSr4EO4VuceM+2Aks/fqoSfnUr/MWxkRS2WNNCrvLRhW26aG5eK3z6UtPCYS2CiUpflt6lJc5CQXBrAksA==",
       "requires": {
         "@edx/frontend-logging": "^2.0.0",
         "axios": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "@cospired/i18n-iso-languages": "^2.0.2",
     "@edx/edx-bootstrap": "^2.0.1",
     "@edx/frontend-analytics": "^1.0.0",
-    "@edx/frontend-auth": "^5.0.0",
+    "@edx/frontend-auth": "^5.1.1",
     "@edx/frontend-component-footer": "^2.0.3",
     "@edx/frontend-component-site-header": "^2.1.4",
     "@edx/frontend-logging": "^2.0.0",

--- a/src/profile/sagas.js
+++ b/src/profile/sagas.js
@@ -135,7 +135,7 @@ export function* handleSaveProfile(action) {
     // The preferences draft is valid if the server didn't complain, so
     // pass it through directly.
     yield put(saveProfileSuccess(accountResult, preferencesResult));
-    yield delay(300);
+    yield delay(1000);
     yield put(closeForm(action.payload.formId));
     yield delay(300);
     yield put(saveProfileReset());

--- a/src/profile/sagas.test.js
+++ b/src/profile/sagas.test.js
@@ -126,7 +126,7 @@ describe('RootSaga', () => {
       // The library would supply the result of the above call
       // as the parameter to the NEXT yield.  Here:
       expect(gen.next(profile).value).toEqual(put(profileActions.saveProfileSuccess(profile, {})));
-      expect(gen.next().value).toEqual(delay(300));
+      expect(gen.next().value).toEqual(delay(1000));
       expect(gen.next().value).toEqual(put(profileActions.closeForm('ze form id')));
       expect(gen.next().value).toEqual(delay(300));
       expect(gen.next().value).toEqual(put(profileActions.saveProfileReset()));


### PR DESCRIPTION
Fixes: https://openedx.atlassian.net/browse/ARCH-687

Users who trigger an API request after being logging out in a separate tab or waiting until after their session expires will continue to be redirected to login, but we will not log an error to NewRelic.

Note: This will not eliminate this error in our logs entirely. We will continue to log this error for an API response of 401 or 403, just not if that request was directed to login_refresh.