### PR TITLE
ARCH-748: update i18n make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,5 @@
-extract_translations: ## no prerequisites so we can control order of operations
-	echo "We have to define this target due to tooling assumptions"
-	echo "Also we have to npm install using this hook b/c there's no other place for it in the current setup"
+requirements:
 	npm install
-	npm run-script i18n_extract
 
 i18n.extract:
     # Pulling display strings from .jsx files into .json files...
@@ -12,6 +9,12 @@ i18n.concat:
     # Gathering JSON messages into one file...
 	./src/i18n/i18n-concat.js ./temp/src ./src/i18n/transifex_input.json
 
+
+# The following make targets are required by our tooling scripts found in:
+# - https://github.com/edx/ecommerce-scripts/tree/master/transifex
+
+extract_translations: | requirements i18n.extract i18n.concat
+
 detect_changed_source_translations:
 	git diff --exit-code ./src/i18n/transifex_input.json
 
@@ -19,7 +22,9 @@ tx_url1 = https://www.transifex.com/api/2/project/edx-platform/resource/frontend
 tx_url2 = https://www.transifex.com/api/2/project/edx-platform/resource/frontend-app-profile/source/
 
 # push translations to Transifex, doing magic so we can include the translator comments
-push_translations: | i18n.extract
+# Note: extract_translations is a prereq that our translation script calls separately.
+push_translations:
+	tx push -s
 	# Adding translator comments...
 	# Fetching strings from Transifex...
 	./node_modules/reactifex/bash_scripts/get_hashed_strings.sh $(tx_url1)


### PR DESCRIPTION
ARCH-7481

update i18n make targets

* update extract_translations to also concat
* update push_translations to push to Transifex
* remove call to i18n.extract as part of push_translations

@albemarle: This PR adds `i18n.concat` to the `extract_translations` that the Jenkins scripts [push script](https://github.com/edx/ecommerce-scripts/blob/master/transifex/push.py#L3-L4) relies on.
I think this solves part of the problem, but having `extract_translations` do everything needed to prep source files to be committed.

Next, I plan to also add a separate script and job (called `update_sources`) to only call `extract_translations`, that can be called daily.

Let me know what you think of this PR and this plan.