### PR TITLE
fix: load google fonts with a link tag

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,6 +4,7 @@
       <title>Learner Profile | edX</title>
       <meta charset="utf-8">
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
+      <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700" rel="stylesheet">
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
The @import still exists inside edx-bootstrap, but this will make the request earlier. 