### PR TITLE
fix: add paragon files to purgecss scan

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,16 @@ Introduction
 
 React app for user account management.
 
+Important Note
+--------------
+
+The production Webpack configuration for this repo uses `Purgecss <https://www.purgecss.com/>`_ 
+to remove unused CSS from the production css file. In webpack/webpack.prod.config.js the Purgecss
+plugin is configured to scan directories to determine what css selectors should remain. Currently
+the src/ directory is scanned along with all @edx/frontend-component* node modules and paragon.
+If you add and use a component in this repo that relies on HTML classes or ids for styling you
+must add it to the Purgecss configuration or it will be unstyled in the production build. 
+
 .. |Build Status| image:: https://api.travis-ci.org/edx/frontend-app-profile.svg?branch=master
    :target: https://travis-ci.org/edx/frontend-app-profile
 .. |Coveralls| image:: https://img.shields.io/coveralls/edx/frontend-app-profile.svg?branch=master

--- a/webpack/webpack.prod.config.js
+++ b/webpack/webpack.prod.config.js
@@ -139,6 +139,8 @@ module.exports = Merge.smart(commonConfig, {
         glob.sync(`${path.resolve(__dirname, '../src')}/**/*`, { nodir: true }),
         // Scan files in any edx frontend-component
         glob.sync(`${path.resolve(__dirname, '../node_modules/@edx/frontend-component')}*/**/*`, { nodir: true }),
+        // Scan files in paragon
+        glob.sync(`${path.resolve(__dirname, '../node_modules/@edx/paragon')}/**/*`, { nodir: true }),
       ),
       // Protect react-css-transition class names
       whitelistPatterns: [/-enter/, /-appear/, /-exit/],


### PR DESCRIPTION
Increases the size of CSS files from 27kb to 45kb each, but now includes all styles for Paragon components.