### PR TITLE
fix: bump frontend-base to 2.2.0 to initialize segment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1029,9 +1029,9 @@
       }
     },
     "@edx/frontend-base": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-base/-/frontend-base-2.1.4.tgz",
-      "integrity": "sha512-Iz3hsJmcKTy1CkD5ml/OveLKyFgD6ZWnSvzVLZTc3C62cJ9Gpp2YliN0gFP9cqCySm01+o7Jznqm+j/Zb+FGpg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-base/-/frontend-base-2.2.0.tgz",
+      "integrity": "sha512-eOoy3Hb6T7n2wJgaYrVYXH4MOpICj364XAzsomL/kUqyIY7lGLC55OAForI6lKZICl8cm21QJzLPYFzHZT/WSQ==",
       "requires": {
         "babel-polyfill": "6.26.0",
         "history": "4.9.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@edx/frontend-analytics": "3.0.0",
     "@edx/frontend-auth": "7.0.1",
-    "@edx/frontend-base": "2.1.4",
+    "@edx/frontend-base": "2.2.0",
     "@edx/frontend-component-footer": "6.0.2",
     "@edx/frontend-component-header": "1.1.2",
     "@edx/frontend-i18n": "3.0.2",

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,7 +1,6 @@
 import 'babel-polyfill';
 
 import { App, AppProvider, APP_ERROR, APP_READY, ErrorPage } from '@edx/frontend-base';
-import { NewRelicLoggingService } from '@edx/frontend-logging';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Route, Switch } from 'react-router-dom';
@@ -35,4 +34,4 @@ App.subscribe(APP_ERROR, (error) => {
   ReactDOM.render(<ErrorPage message={error.message} />, document.getElementById('root'));
 });
 
-App.initialize({ messages: [appMessages, headerMessages], loggingService: NewRelicLoggingService });
+App.initialize({ messages: [appMessages, headerMessages] });


### PR DESCRIPTION
frontend-base 2.1.x had a bug where segment wasn’t being initialized.  Now it is.

Also allowing frontend-base to use its default logging service, which is NewRelicLoggingService.