### PR TITLE
fix: send analytics events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1029,9 +1029,9 @@
       }
     },
     "@edx/frontend-base": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@edx/frontend-base/-/frontend-base-4.0.1.tgz",
-      "integrity": "sha512-IEyrorssh3uwRqXYmr7UFVtiz5MtpmnmysA9faCvi2KL4QVP+S9LQYv/48AFmTzNF3gqhO8kRT69YsawX4bdiA==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@edx/frontend-base/-/frontend-base-4.1.0.tgz",
+      "integrity": "sha512-jGHCsQ4um6sWrh3L0ZJm+tBmmtGWefS1ULR9PNi6sDrXgKa1gceBg2W/uYzez0glMtS7HRn5zJ1kRpJHbDW7aA==",
       "requires": {
         "babel-polyfill": "6.26.0",
         "history": "4.9.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@edx/frontend-analytics": "3.0.0",
     "@edx/frontend-auth": "7.0.1",
-    "@edx/frontend-base": "4.0.1",
+    "@edx/frontend-base": "4.1.0",
     "@edx/frontend-component-footer": "9.0.0",
     "@edx/frontend-component-header": "1.1.4",
     "@edx/frontend-i18n": "3.0.2",


### PR DESCRIPTION
frontend-base wasn’t calling identifyAuthenticatedUser and sendPageEvent.  Version 4.1.0 does.