### PR TITLE
Updated the build status badge to point to travis-ci.com

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,8 +56,8 @@ Notes
 
 The production Webpack configuration for this repo uses `Purgecss <https://www.purgecss.com/>`__ to remove unused CSS from the production css file. In ``webpack.prod.config.js`` the Purgecss plugin is configured to scan directories to determine what css selectors should remain. Currently the src/ directory is scanned along with all ``@edx/frontend-component*`` node modules and ``@edx/paragon``. **If you add and use a component in this repo that relies on HTML classes or ids for styling you must add it to the Purgecss configuration or it will be unstyled in the production build.**
 
-.. |Build Status| image:: https://api.travis-ci.org/edx/frontend-app-profile.svg?branch=master
-   :target: https://travis-ci.org/edx/frontend-app-profile
+.. |Build Status| image:: https://api.travis-ci.com/edx/frontend-app-profile.svg?branch=master
+   :target: https://travis-ci.com/edx/frontend-app-profile
 .. |Codecov| image:: https://img.shields.io/codecov/c/github/edx/frontend-app-profile
    :target: https://codecov.io/gh/edx/frontend-app-profile
 .. |npm_version| image:: https://img.shields.io/npm/v/@edx/frontend-app-profile.svg


### PR DESCRIPTION
Updated the README file.
Build status badge is now pointing to 'travis-ci.com' instead of 'travis-ci.org'

JIRA: https://openedx.atlassian.net/browse/BOM-2089