### PR TITLE
build: add module.config.js to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ temp/babel-plugin-react-intl
 /.vscode
 /temp
 /npm-dist
+/module.config.js


### PR DESCRIPTION
module.config.js is a file manually created by developers in their environment that allows them to link local libraries into their build.  It should never be committed.