### PR TITLE
chore: let renovate be more liberal about what it merges

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,9 +1,15 @@
 {
   "extends": [
-    "config:base"
+    "config:base",
+    ":automergeLinters",
+    ":automergeTesters",
+    ":automergeMinor",
+    ":noUnscheduledUpdates",
+    ":semanticCommits"
   ],
-  "patch": {
-    "automerge": true
-  },
-  "rebaseStalePrs": true
+  "rebaseStalePrs": true,
+  "schedule": [
+    "every weekend"
+  ],
+  "timezone": "America/New_York"
 }


### PR DESCRIPTION
We've adopted a looser renovate config that will auto-merge more things in other repositories, and it's worked out fine.  I just lifted this config from frontend-platform, which was itself based on prospectus (private).