### PR TITLE
chore: upgrade paragon and corresponding snapshots

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2063,9 +2063,9 @@
       }
     },
     "@edx/paragon": {
-      "version": "16.6.1",
-      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-16.6.1.tgz",
-      "integrity": "sha512-OpfcWhNsgcTfJgxuHm5yZ35FLOPddinENRVd/SzkmUuUYjqsvxlJW5T53yN2OZctP770nvim1qmFAHm+Zyzxhg==",
+      "version": "16.7.0",
+      "resolved": "https://registry.npmjs.org/@edx/paragon/-/paragon-16.7.0.tgz",
+      "integrity": "sha512-WVcbFKv2OzxAQuiJ8BskrIo+ybv8p7QUEC5Ondg+/eWTt3aYtfYVvmDy7000JwPdsktVS3yKtMoDY2VbdgCNug==",
       "requires": {
         "@fortawesome/fontawesome-svg-core": "^1.2.30",
         "@fortawesome/free-solid-svg-icons": "^5.14.0",
@@ -2091,30 +2091,30 @@
       },
       "dependencies": {
         "@fortawesome/fontawesome-common-types": {
-          "version": "0.2.35",
-          "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.35.tgz",
-          "integrity": "sha512-IHUfxSEDS9dDGqYwIW7wTN6tn/O8E0n5PcAHz9cAaBoZw6UpG20IG/YM3NNLaGPwPqgjBAFjIURzqoQs3rrtuw=="
+          "version": "0.2.36",
+          "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz",
+          "integrity": "sha512-a/7BiSgobHAgBWeN7N0w+lAhInrGxksn13uK7231n2m8EDPE3BMCl9NZLTGrj9ZXfCmC6LM0QLqXidIizVQ6yg=="
         },
         "@fortawesome/fontawesome-svg-core": {
-          "version": "1.2.35",
-          "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.35.tgz",
-          "integrity": "sha512-uLEXifXIL7hnh2sNZQrIJWNol7cTVIzwI+4qcBIq9QWaZqUblm0IDrtSqbNg+3SQf8SMGHkiSigD++rHmCHjBg==",
+          "version": "1.2.36",
+          "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-1.2.36.tgz",
+          "integrity": "sha512-YUcsLQKYb6DmaJjIHdDWpBIGCcyE/W+p/LMGvjQem55Mm2XWVAP5kWTMKWLv9lwpCVjpLxPyOMOyUocP1GxrtA==",
           "requires": {
-            "@fortawesome/fontawesome-common-types": "^0.2.35"
+            "@fortawesome/fontawesome-common-types": "^0.2.36"
           }
         },
         "@fortawesome/free-solid-svg-icons": {
-          "version": "5.15.3",
-          "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.3.tgz",
-          "integrity": "sha512-XPeeu1IlGYqz4VWGRAT5ukNMd4VHUEEJ7ysZ7pSSgaEtNvSo+FLurybGJVmiqkQdK50OkSja2bfZXOeyMGRD8Q==",
+          "version": "5.15.4",
+          "resolved": "https://registry.npmjs.org/@fortawesome/free-solid-svg-icons/-/free-solid-svg-icons-5.15.4.tgz",
+          "integrity": "sha512-JLmQfz6tdtwxoihXLg6lT78BorrFyCf59SAwBM6qV/0zXyVeDygJVb3fk+j5Qat+Yvcxp1buLTY5iDh1ZSAQ8w==",
           "requires": {
-            "@fortawesome/fontawesome-common-types": "^0.2.35"
+            "@fortawesome/fontawesome-common-types": "^0.2.36"
           }
         },
         "@fortawesome/react-fontawesome": {
-          "version": "0.1.14",
-          "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.14.tgz",
-          "integrity": "sha512-4wqNb0gRLVaBm/h+lGe8UfPPivcbuJ6ecI4hIgW0LjI7kzpYB9FkN0L9apbVzg+lsBdcTf0AlBtODjcSX5mmKA==",
+          "version": "0.1.15",
+          "resolved": "https://registry.npmjs.org/@fortawesome/react-fontawesome/-/react-fontawesome-0.1.15.tgz",
+          "integrity": "sha512-/HFHdcoLESxxMkqZAcZ6RXDJ69pVApwdwRos/B2kiMWxDSAX2dFK8Er2/+rG+RsrzWB/dsAyjefLmemgmfE18g==",
           "requires": {
             "prop-types": "^15.7.2"
           }
@@ -2910,9 +2910,9 @@
       }
     },
     "@popperjs/core": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.9.2.tgz",
-      "integrity": "sha512-VZMYa7+fXHdwIq1TDhSXoVmSPEGM/aa+6Aiq3nVVJ9bXr24zScr+NlKFKC3iPljA7ho/GAZr+d2jOf5GIRC30Q=="
+      "version": "2.9.3",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.9.3.tgz",
+      "integrity": "sha512-xDu17cEfh7Kid/d95kB6tZsLOmSWKCZKtprnhVepjsSaCij+lM3mItSJDuuHDMbCWTh8Ejmebwb+KONcCJ0eXQ=="
     },
     "@redux-saga/core": {
       "version": "1.1.3",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "@edx/frontend-component-footer": "10.1.5",
     "@edx/frontend-component-header": "2.3.0",
     "@edx/frontend-platform": "1.11.3",
-    "@edx/paragon": "16.6.1",
+    "@edx/paragon": "16.7.0",
     "@fortawesome/fontawesome-svg-core": "1.2.25",
     "@fortawesome/free-brands-svg-icons": "5.7.2",
     "@fortawesome/free-regular-svg-icons": "5.7.2",

--- a/src/profile/__snapshots__/ProfilePage.test.jsx.snap
+++ b/src/profile/__snapshots__/ProfilePage.test.jsx.snap
@@ -327,9 +327,8 @@ exports[`<ProfilePage /> Renders correctly in various states viewing own profile
           >
             View My Records
             <span
-              className="d-inline-block align-text-top"
+              className="d-inline-block align-middle ml-2"
             >
-               
               <span
                 className="pgn__icon"
                 style={
@@ -405,9 +404,8 @@ exports[`<ProfilePage /> Renders correctly in various states viewing own profile
           >
             View My Records
             <span
-              className="d-inline-block align-text-top"
+              className="d-inline-block align-middle ml-2"
             >
-               
               <span
                 className="pgn__icon"
                 style={
@@ -1222,9 +1220,8 @@ exports[`<ProfilePage /> Renders correctly in various states viewing own profile
                       >
                         View Certificate
                         <span
-                          className="d-inline-block align-text-top"
+                          className="d-inline-block align-middle ml-2"
                         >
-                           
                           <span
                             className="pgn__icon"
                             style={
@@ -1378,9 +1375,8 @@ exports[`<ProfilePage /> Renders correctly in various states while saving an edi
           >
             View My Records
             <span
-              className="d-inline-block align-text-top"
+              className="d-inline-block align-middle ml-2"
             >
-               
               <span
                 className="pgn__icon"
                 style={
@@ -1456,9 +1452,8 @@ exports[`<ProfilePage /> Renders correctly in various states while saving an edi
           >
             View My Records
             <span
-              className="d-inline-block align-text-top"
+              className="d-inline-block align-middle ml-2"
             >
-               
               <span
                 className="pgn__icon"
                 style={
@@ -2344,9 +2339,8 @@ exports[`<ProfilePage /> Renders correctly in various states while saving an edi
                       >
                         View Certificate
                         <span
-                          className="d-inline-block align-text-top"
+                          className="d-inline-block align-middle ml-2"
                         >
-                           
                           <span
                             className="pgn__icon"
                             style={
@@ -3313,9 +3307,8 @@ exports[`<ProfilePage /> Renders correctly in various states without credentials
                       >
                         View Certificate
                         <span
-                          className="d-inline-block align-text-top"
+                          className="d-inline-block align-middle ml-2"
                         >
-                           
                           <span
                             className="pgn__icon"
                             style={


### PR DESCRIPTION
This replaces and fixes #452 

Tests were failing there due to outdated snapshots.

See https://github.com/edx/paragon/pull/798 for the corresponding change to paragon.